### PR TITLE
Stop using deprecated alert class. Closes #27

### DIFF
--- a/settings/html.completion.cson
+++ b/settings/html.completion.cson
@@ -229,7 +229,7 @@
 
       'badge'
       'list-group-item'
-      'alert-dismissable'
+      'alert-dismissible'
       'alert-success'
       'alert-info'
       'alert-warning'


### PR DESCRIPTION
This change removes already deprecated .alert-dismissable
from autocompletion hints introducing current alert variant class.
Source: http://git.io/vOJfN

Thanks!